### PR TITLE
Fix for AWS bucket creation issue on Qwiklabs.

### DIFF
--- a/deployment/aws/main.tf
+++ b/deployment/aws/main.tf
@@ -15,7 +15,8 @@
 ############################################################################################
 
 provider "aws" {
-  region = "${var.aws_region_name}"
+  region  = "${var.aws_region_name}"
+  version = "1.53.0"
 }
 
 resource "aws_key_pair" "ssh_key" {
@@ -140,14 +141,14 @@ resource "aws_security_group" "firewall_mgmt_sg" {
     to_port     = "22"
     from_port   = "22"
     protocol    = "tcp"
-    cidr_blocks = ["${var.allowed_mgmt_cidr}"]
+    cidr_blocks = "${var.allowed_mgmt_cidr}"
   }
 
   ingress {
     to_port     = "443"
     from_port   = "443"
     protocol    = "tcp"
-    cidr_blocks = ["${var.allowed_mgmt_cidr}"]
+    cidr_blocks = "${var.allowed_mgmt_cidr}"
   }
 
   egress {

--- a/deployment/aws/variables.tf
+++ b/deployment/aws/variables.tf
@@ -25,7 +25,7 @@ variable "public_key_file" {
 }
 
 variable "allowed_mgmt_cidr" {
-  description = "The source address that will be allowed to access the lab environment"
-  type        = "string"
-  default     = "0.0.0.0/0"
+  description = "The source addresses that will be allowed to access the lab environment"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
 }

--- a/docs/02-deploy/deploy-aws.rst
+++ b/docs/02-deploy/deploy-aws.rst
@@ -78,12 +78,13 @@ public IP address.
 
 .. code-block:: bash
 
-    aws_region_name     = ""
-    public_key_file     = ""
-    allowed_mgmt_cidr   = ""
+    aws_region_name     = "us-west-2"
+    public_key_file     = "~/.ssh/lab_ssh_key.pub"
+    allowed_mgmt_cidr   = ["<YOUR LAUNCHPAD IP>", "<YOUR PUBLIC IP>"]
 
-Use the following command to determine your public IP address.  Simply take the
-resulting value and append ``/32`` to it for the ``allowed_mgmt_cidr`` value.
+Use the following command to determine your public IP address.  Both the
+launchpad IP address and your public IP address will need ``/32`` appended to
+them for the ``allowed_mgmt_cidr`` value.
 
 .. code-block:: bash
 


### PR DESCRIPTION
- Locks AWS provider version to 1.53.0.
- Also changes `allowed_mgmt_cidr` to a list, since connections to the firewall will be done from the launchpad VM and the student's workstation.