### PR TITLE
Add optional flag to specify AZ.

### DIFF
--- a/deployment/aws/main.tf
+++ b/deployment/aws/main.tf
@@ -37,13 +37,15 @@ module "vpc" {
   name = "Multicloud-AWS"
   cidr = "10.5.0.0/16"
 
+  specify_az = "${var.specify_az}"
+
   mgmt_subnet   = "10.5.0.0/24"
   public_subnet = "10.5.1.0/24"
   web_subnet    = "10.5.2.0/24"
   db_subnet     = "10.5.3.0/24"
 
   tags {
-	Environment = "Multicloud-AWS"
+    Environment = "Multicloud-AWS"
   }
 }
 

--- a/deployment/aws/modules/vpc/main.tf
+++ b/deployment/aws/modules/vpc/main.tf
@@ -16,7 +16,7 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "mgmt" {
   vpc_id            = "${aws_vpc.vpc.id}"
   cidr_block        = "${var.mgmt_subnet}"
-  availability_zone = "${random_shuffle.az.result[0]}"
+  availability_zone = "${var.specify_az != "0" ? var.specify_az: random_shuffle.az.result[0]}"
 
   tags = "${merge(map("Name", format("%s-MgmtSubnet", var.name)), var.tags)}"
 }
@@ -24,7 +24,7 @@ resource "aws_subnet" "mgmt" {
 resource "aws_subnet" "public" {
   vpc_id            = "${aws_vpc.vpc.id}"
   cidr_block        = "${var.public_subnet}"
-  availability_zone = "${random_shuffle.az.result[0]}"
+  availability_zone = "${var.specify_az != "0" ? var.specify_az : random_shuffle.az.result[0]}"
 
   tags = "${merge(map("Name", format("%s-PublicSubnet", var.name)), var.tags)}"
 }
@@ -32,7 +32,7 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "web" {
   vpc_id            = "${aws_vpc.vpc.id}"
   cidr_block        = "${var.web_subnet}"
-  availability_zone = "${random_shuffle.az.result[0]}"
+  availability_zone = "${var.specify_az != "0" ? var.specify_az : random_shuffle.az.result[0]}"
 
   tags = "${merge(map("Name", format("%s-WebSubnet", var.name)), var.tags)}"
 }
@@ -40,7 +40,7 @@ resource "aws_subnet" "web" {
 resource "aws_subnet" "db" {
   vpc_id            = "${aws_vpc.vpc.id}"
   cidr_block        = "${var.db_subnet}"
-  availability_zone = "${random_shuffle.az.result[0]}"
+  availability_zone = "${var.specify_az != "0" ? var.specify_az : random_shuffle.az.result[0]}"
 
   tags = "${merge(map("Name", format("%s-DbSubnet", var.name)), var.tags)}"
 }

--- a/deployment/aws/modules/vpc/variables.tf
+++ b/deployment/aws/modules/vpc/variables.tf
@@ -30,6 +30,11 @@ variable "db_subnet" {
 ## Optional Variables                                                ##
 #######################################################################
 
+variable "specify_az" {
+  description = "Optionally specify availability zone for subnets and instances."
+  default     = false
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}

--- a/deployment/aws/outputs.tf
+++ b/deployment/aws/outputs.tf
@@ -14,6 +14,9 @@
 # limitations under the License.
 ############################################################################################
 
+output "vpc" {
+  value = "${module.vpc.vpc_id}"
+}
 
 output "firewall_mgmt_ip" {
   value = "${module.firewall.fw_mgmt_eip}"

--- a/deployment/aws/variables.tf
+++ b/deployment/aws/variables.tf
@@ -29,3 +29,8 @@ variable "allowed_mgmt_cidr" {
   type        = "list"
   default     = ["0.0.0.0/0"]
 }
+
+variable "specify_az" {
+  description = "Optionally specify availability zone for subnets and instances."
+  default     = false
+}


### PR DESCRIPTION
Can set `specify_az` in `terraform.tfvars` file to manually set availability zone in AWS.

Also output VPC id for VM information sources.